### PR TITLE
Fix cosine LR scheduler min_lr

### DIFF
--- a/pillar/utils/cosine_with_warmup.py
+++ b/pillar/utils/cosine_with_warmup.py
@@ -27,8 +27,8 @@ class CosineAnnealingWarmup(LRScheduler):
             ]
         else:
             return [
-                self.min_lr
-                + (base_lr - self.min_lr)
+                self.min_lr * group["lr_scale"]
+                + (base_lr - self.min_lr * group["lr_scale"])
                 * 0.5
                 * (
                     1.0

--- a/pillar/utils/lr_decay.py
+++ b/pillar/utils/lr_decay.py
@@ -13,7 +13,7 @@ import json
 from pillar.utils.logging import logger
 
 
-def param_groups_lrd(model, base_lr, weight_decay=0.05, no_weight_decay_list=[], layer_decay=0.75):
+def param_groups_lrd(model, weight_decay=0.05, no_weight_decay_list=[], layer_decay=0.75):
     """
     Parameter groups for layer-wise lr decay
     Following BEiT: https://github.com/microsoft/unilm/blob/master/beit/optim_factory.py#L58
@@ -45,12 +45,12 @@ def param_groups_lrd(model, base_lr, weight_decay=0.05, no_weight_decay_list=[],
             this_scale = layer_scales[layer_id]
 
             param_group_names[group_name] = {
-                "lr": base_lr * this_scale,
+                "lr_scale": this_scale,
                 "weight_decay": this_decay,
                 "params": [],
             }
             param_groups[group_name] = {
-                "lr": base_lr * this_scale,
+                "lr_scale": this_scale,
                 "weight_decay": this_decay,
                 "params": [],
             }

--- a/scripts/train.py
+++ b/scripts/train.py
@@ -303,12 +303,13 @@ def build_optimizer(args, model):
 
         param_groups = param_groups_lrd(
             model,
-            base_lr=base_lr,
             weight_decay=weight_decay,
             no_weight_decay_list=no_weight_decay_list,
             layer_decay=args.optimizer.layer_decay,
         )
 
+        for group in param_groups:
+            group["lr"] = base_lr * group["lr_scale"]
         # Remove lr and weight_decay from kwargs since they're in param_groups
         optimizer_kwargs_filtered = {k: v for k, v in optimizer_kwargs.items() if k not in ["lr", "weight_decay"]}
         optimizer = getattr(torch.optim, optimizer_type)(param_groups, **optimizer_kwargs_filtered)


### PR DESCRIPTION
Layer decay resulted in incorrect min_lr for lower layers as only the base_lr was updated for those layers. In line with the source layer decay code (beit repo), lr_scale was added rather than directly modifying the lr. The lr_scale is then used to modify base_lr and min_lr.